### PR TITLE
Made 'This Week' view action buttons visible for months with no timesheet yet.

### DIFF
--- a/src/components/Week.vue
+++ b/src/components/Week.vue
@@ -158,7 +158,7 @@ div
 
           div(class='card-body p-0')
 
-          div(class='card-footer' v-if='getTimesheetForDay(date)')
+          div(class='card-footer')
             div(class='text-center')
               div(class='btn-group')
                 button(class='btn btn-outline-dark btn-sm' @click='addPerformance(date)' v-b-tooltip="{boundary: 'window'}" title='Log performance')


### PR DESCRIPTION
'This Week' view buttons for 'Whereabout', 'Log Performance', and 'Request Leave' were hidden for months with no timesheet yet. 
Now, they are visible.