### PR TITLE
fix: distinguish sickness and holiday, also show half- or full-day absence refs #104696, #46517

### DIFF
--- a/src/components/widgets/AbsenceWidget.vue
+++ b/src/components/widgets/AbsenceWidget.vue
@@ -90,6 +90,7 @@ export default {
           const user = store.getters.users[i];
           const leave = res.data[user.id][this.selectedDay.format('YYYY-MM-DD')]
           if(leave['sickness'].length > 0){
+            console.log(leave["sickness"])
             // is sick
             user["absenceIcon"] = "fa fa-plus-square plus-square"
             user["absenceType"] = "Sickness"
@@ -100,11 +101,10 @@ export default {
             user["absenceIcon"] = "fa fa-calendar calendar"
             user["absenceType"] = "Other"
 
-            //! prototype #46517
-            const leaveStart = moment(leave["leave"][0]["starts_at"]) // todo: not just 0
+            const leaveStart = moment(leave["leave"][0]["starts_at"])
             const leaveEnd = moment(leave["leave"][0]["ends_at"])
-            user["fullDay"] = leaveEnd.diff(leaveStart,"hours") > leave["work_hours"] / 2 ? "fa fa-hourglass hourglass" : "fa fa-hourglass-end hourglass-end"
-            user["dayTooltip"] = leaveEnd.diff(leaveStart,"hours") > leave["work_hours"] / 2 ? "Full-day" : "Half-day"
+            user["fullDay"] = leaveEnd.diff(leaveStart,"hours") >= leave["work_hours"] ? "fa fa-hourglass hourglass" : "fa fa-hourglass-end hourglass-end"
+            user["dayTooltip"] = leaveEnd.diff(leaveStart,"hours") >= leave["work_hours"] ? "Full-day" : "Half-day"
             
             this.absentUsers.push(user)
           }

--- a/src/components/widgets/AbsenceWidget.vue
+++ b/src/components/widgets/AbsenceWidget.vue
@@ -86,7 +86,6 @@ export default {
         }
       }).then((res) => {
         this.absentUsers = []
-        this.userHours = res.data[store.getters.user.id][moment(moment.now()).format("YYYY-MM-DD")]["work_hours"]
         console.log(this.userHours)
         for (let i = 0; i < store.getters.users.length; i++) {
           const user = store.getters.users[i];

--- a/src/components/widgets/AbsenceWidget.vue
+++ b/src/components/widgets/AbsenceWidget.vue
@@ -90,7 +90,6 @@ export default {
           const user = store.getters.users[i];
           const leave = res.data[user.id][this.selectedDay.format('YYYY-MM-DD')]
           if(leave['sickness'].length > 0){
-            console.log(leave["sickness"])
             // is sick
             user["absenceIcon"] = "fa fa-plus-square plus-square"
             user["absenceType"] = "Sickness"

--- a/src/components/widgets/AbsenceWidget.vue
+++ b/src/components/widgets/AbsenceWidget.vue
@@ -86,7 +86,6 @@ export default {
         }
       }).then((res) => {
         this.absentUsers = []
-        console.log(this.userHours)
         for (let i = 0; i < store.getters.users.length; i++) {
           const user = store.getters.users[i];
           const leave = res.data[user.id][this.selectedDay.format('YYYY-MM-DD')]
@@ -104,7 +103,6 @@ export default {
             //! prototype #46517
             const leaveStart = moment(leave["leave"][0]["starts_at"]) // todo: not just 0
             const leaveEnd = moment(leave["leave"][0]["ends_at"])
-            console.log(leaveEnd.diff(leaveStart,"hours"))
             user["fullDay"] = leaveEnd.diff(leaveStart,"hours") > leave["work_hours"] / 2 ? "fa fa-hourglass hourglass" : "fa fa-hourglass-end hourglass-end"
             user["dayTooltip"] = leaveEnd.diff(leaveStart,"hours") > leave["work_hours"] / 2 ? "Full-day" : "Half-day"
             


### PR DESCRIPTION
![Screenshot from Yayata displaying the icons I added](https://files.catbox.moe/gqt9f6.png)

I don't think you can be sick for only half-day, so no *full-day or half-day* icon is displayed there. All icons have tooltips.

Half-days are automatically all leaves which are not for the whole day.